### PR TITLE
Apm troubleshooting demo 2

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: adservice
 spec:
+  selector:
+    matchLabels:
+      app: adservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cartservice
 spec:
+  selector:
+    matchLabels:
+      app: cartservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: checkoutservice
 spec:
+  selector:
+    matchLabels:
+      app: checkoutservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: currencyservice
 spec:
+  selector:
+    matchLabels:
+      app: currencyservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emailservice
 spec:
+  selector:
+    matchLabels:
+      app: emailservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
 spec:
+  selector:
+    matchLabels:
+      app: frontend
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
 spec:
+  selector:
+    matchLabels:
+      app: loadgenerator
   replicas: 1
   template:
     metadata:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: paymentservice
 spec:
+  selector:
+    matchLabels:
+      app: paymentservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productcatalogservice
 spec:
+  selector:
+    matchLabels:
+      app: productcatalogservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: recommendationservice
 spec:
+  selector:
+    matchLabels:
+      app: recommendationservice
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-cart
 spec:
+  selector:
+    matchLabels:
+      app: redis-cart
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shippingservice
 spec:
+  selector:
+    matchLabels:
+      app: shippingservice
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fix for the error thrown by skaffold during qwiklabs practice using kubernetes v1.18 

 _error: unable to recognize "deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"_